### PR TITLE
Re-order + update *Installation* and *Prerequisites* sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,17 @@
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
+## Prerequisites
+
+* Node >= 12
+* Docker >= 18 and Docker Compose
+* Angular CLI installed globally `npm install -g @angular/cli`
+
 ## Installation
 
 ```bash
 npm install
 ```
-
-## Prerequisites
-
-* Node >= 12
-* Docker >= 18
-* Angular CLI installed globally `npm install -g @angular/cli`
-* Start a Postgres server on localhost port 5432.  The server should grant full access to a database called `buddybudget`
-  with login credentials `buddybudget:buddybudget`.  (Could be achieved by running `docker-compose up buddybudget-sql`.)
 
 ## Running the App
  

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "MIT",
   "scripts": {
-    "preinstall" : "npm --prefix ./client install ./client",
+    "preinstall": "npm --prefix ./client install ./client",
     "build": "rimraf dist && tsc -p tsconfig.build.json && cd client && npm run build",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "ts-node -r tsconfig-paths/register src/main.ts",


### PR DESCRIPTION
Because:
- Can't do the npm install unless prerequisites are put in place
- Docker Compose missing
- Wordiness about Postgres server no longer needed with the explicit
  instruction on `docker-compose up buddybudget-sql` before
  running the app